### PR TITLE
refactor(exports)!: change names

### DIFF
--- a/__tests__/types.spec.js
+++ b/__tests__/types.spec.js
@@ -1,8 +1,8 @@
-const { conventionalTypes, conventionalRubyTypes } = require('../src');
+const { convTypes, types } = require('../src');
 
 describe('types', () => {
   it('conventionalTypes', () => {
-    expect(conventionalTypes).toStrictEqual([
+    expect(convTypes).toStrictEqual([
       'feat',
       'fix',
       'docs',
@@ -18,7 +18,7 @@ describe('types', () => {
   });
 
   it('conventionalRubyTypes', () => {
-    expect(conventionalRubyTypes).toStrictEqual([
+    expect(types).toStrictEqual([
       'feat',
       'fix',
       'docs',

--- a/__tests__/typesInfo.spec.js
+++ b/__tests__/typesInfo.spec.js
@@ -1,15 +1,15 @@
-const { types: typesInfo } = require('conventional-commit-types');
+const { types } = require('conventional-commit-types');
 
-const { conventionalTypesInfo, conventionalRubyTypesInfo } = require('../src');
+const { convTypesInfo, typesInfo } = require('../src');
 
 describe('typesInfo', () => {
   it('conventionalTypesInfo', () => {
-    expect(conventionalTypesInfo).toStrictEqual(typesInfo);
+    expect(convTypesInfo).toStrictEqual(types);
   });
 
   it('conventionalRubyTypesInfo', () => {
-    expect(conventionalRubyTypesInfo).toStrictEqual({
-      ...typesInfo,
+    expect(typesInfo).toStrictEqual({
+      ...types,
       wip: {
         description: "A 'wip' type. Use this ONLY if you plan to cherry-pick its changes later into your working branch",
         title: 'WIP',

--- a/src/index.js
+++ b/src/index.js
@@ -1,19 +1,19 @@
-const { types: conventionalTypesInfo } = require('conventional-commit-types');
+const { types: convTypesInfo } = require('conventional-commit-types');
 
 const customTypesInfo = require('./customTypesInfo');
 
-const conventionalRubyTypesInfo = {
-  ...conventionalTypesInfo,
+const typesInfo = {
+  ...convTypesInfo,
   ...customTypesInfo,
 };
 
-module.exports.conventionalTypesInfo = conventionalTypesInfo;
+module.exports.convTypesInfo = convTypesInfo;
 
-module.exports.conventionalTypes = Object.keys(conventionalTypesInfo);
+module.exports.convTypes = Object.keys(convTypesInfo);
 
-module.exports.conventionalRubyTypesInfo = conventionalRubyTypesInfo;
+module.exports.typesInfo = typesInfo;
 
-module.exports.conventionalRubyTypes = Object.keys(conventionalRubyTypesInfo);
+module.exports.types = Object.keys(typesInfo);
 
 module.exports.configureWidths = function configureWidths(widths = {}) {
   const { maxHeaderWidth = 50, maxLineWidth = 72 } = widths;


### PR DESCRIPTION
BREAKING CHANGE: export names are changed since the package name is
already long

Closes: #2